### PR TITLE
Shr 255 fix json sample

### DIFF
--- a/aws-example/README.md
+++ b/aws-example/README.md
@@ -20,7 +20,6 @@ corresponding objects from the service using an authenticating API key.
    For an example of an AWS CloudFormation implementation, please see the AWS CloudFormation template
    included in the aws-example folder, available in JSON (cloudformation_sqs.json)
    or in YAML (cloudformation_sqs.yaml) format.
-    .
 
    This can be built using the [AWS command line interface](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html).
 
@@ -37,55 +36,27 @@ corresponding objects from the service using an authenticating API key.
    The created SQS queue needs a policy (included as part of the example CloudFormation template)
    that allows the service (ARN sent in step 1) to [send messages](http://docs.aws.amazon.com/sns/latest/dg/SendMessageToSQS.html#SendMessageToSQS.sqs.permissions) to it.
 
-   Ensure your SQS queue access policy includes the following statement:
+   Ensure your SQS queue access policy includes the following statement (this will already be in place if you used one of the CloudFormation templates to create the queue):
 
-JSON:
 ```
 {
-    "Version": "2012-10-17",
-    "Statement": [{
-            "Action": [
-                "sqs:SendMessage"
-            ],
-            "Effect": "Allow",
-            "Resource": {
-                "Fn::GetAtt": ["<your-queue-name>", "Arn"]
-            },
-            "Condition": {
-                "ArnEquals": {
-                   "aws:SourceArn": "<insert-service-arn-supplied-by-Met-Office>"
-                   }
-                }
-            }]
-        },
-        "Queues": [{
-            "<your-queue-name>"
-        }]
-      }
-   }
+     "Version":"2012-10-17",
+     "Id": "SQSQueuePolicyToReceiveServiceNotifications",
+     "Statement":[
+        {
+           "Effect": "Allow",
+           "Principal": "*",
+           "Action": "sqs:SendMessage",
+           "Resource": "<your-queue-arn>",
+           "Condition":{
+              "ArnEquals":{
+                 "aws:SourceArn":"<service-arn-supplied-by-Met-Office>"
+              }
+           }
+        }
+     ]
 }
 ```
-
-YAML:
-```
-  SQSQueuePolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal: "*"
-          Action:
-          - sqs:SendMessage
-          Resource: !GetAtt <your-queue-name>.Arn
-          Condition:
-            ArnEquals:
-              aws:SourceArn: <insert-service-arn-supplied-by-Met-Office>
-      Queues:
-      - <your-queue-name>
-```
-
 
 3. ### Configure access credentials and permissions for your AWS account.
 


### PR DESCRIPTION
The existing JSON example was invalid, there was also a mismatch between the JSON and the YAML.

This section refers to checking your SQS queue policy contains this statement. It would never display as YAML like this, and would not have the CloudFormation wrapper (the CloudFormation code is already contained in the supplied template files).

Updated to show how it should look in  the actual generated policy (which is JSON, and purely the policy without the CF wrappers).